### PR TITLE
Add config test and pytest dev dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 aiogram==3.0.0b7
 instaloader==4.11
 python-dotenv==1.0.0
+
+# Development dependencies
+pytest==8.3.5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+import types
+
+
+def test_loads_env_variables(monkeypatch):
+    # Provide a minimal stub for the dotenv module
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    monkeypatch.setenv("TELEGRAM_TOKEN", "token123")
+    monkeypatch.setenv("INSTAGRAM_USER", "user123")
+    monkeypatch.setenv("INSTAGRAM_PASSWORD", "pass123")
+    monkeypatch.setenv("SESSION_DIR", "my_sessions")
+
+    # Reload config after setting env vars and stubbing dotenv
+    config = importlib.import_module("config")
+    importlib.reload(config)
+
+    assert config.TELEGRAM_TOKEN == "token123"
+    assert config.INSTAGRAM_USER == "user123"
+    assert config.INSTAGRAM_PASSWORD == "pass123"
+    assert config.SESSION_DIR == "my_sessions"


### PR DESCRIPTION
## Summary
- test that environment variables are loaded in `config.py`
- stub `dotenv` in test to avoid external dependency
- add `pytest` as a development dependency

## Testing
- `pytest -q`