### PR TITLE
Add HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A powerful Telegram bot to interact with Instagram — fetch profile information
 - **/download_posts `<username>`**: Download the latest 5 posts of a public account.
 - **/download_stories**: Download all current stories of the users you follow.
 - **Rate limiting & sessions**: Built on [Instaloader](https://instaloader.github.io/) with automatic throttling and session caching.
-- **Web API**: Access the same features through a FastAPI server.
+- **Web API**: Access the same features through a FastAPI server, served over HTTPS.
 
 ## 🔧 Installation
 
@@ -39,6 +39,9 @@ A powerful Telegram bot to interact with Instagram — fetch profile information
    TELEGRAM_TOKEN=your_telegram_bot_token_here
    INSTAGRAM_USER=your_instagram_username
    INSTAGRAM_PASSWORD=your_instagram_password
+   # Optional: paths to SSL certificate and key for HTTPS
+   SSL_CERTFILE=/path/to/cert.pem
+   SSL_KEYFILE=/path/to/key.pem
    ```
 
 5. Run the bot:
@@ -50,7 +53,8 @@ A powerful Telegram bot to interact with Instagram — fetch profile information
 6. Launch the optional web interface:
 
    ```bash
-   uvicorn web_app:app --reload
+   uvicorn web_app:app --reload \
+       --ssl-keyfile "$SSL_KEYFILE" --ssl-certfile "$SSL_CERTFILE"
    ```
 
 ## ⚙️ Configuration (`config.py`)
@@ -65,6 +69,8 @@ TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")  # Telegram Bot API token
 INSTAGRAM_USER = os.getenv("INSTAGRAM_USER")  # Instagram username for login
 INSTAGRAM_PASSWORD = os.getenv("INSTAGRAM_PASSWORD")  # Instagram password for login
 SESSION_DIR = os.getenv("SESSION_DIR", "sessions")  # directory for Instaloader sessions
+SSL_CERTFILE = os.getenv("SSL_CERTFILE")  # path to SSL certificate
+SSL_KEYFILE = os.getenv("SSL_KEYFILE")  # path to SSL key
 ```
 
 ## 📜 Usage

--- a/config.py
+++ b/config.py
@@ -11,3 +11,7 @@ INSTAGRAM_USER: str = os.getenv("INSTAGRAM_USER", "")
 INSTAGRAM_PASSWORD: str = os.getenv("INSTAGRAM_PASSWORD", "")
 # Directory where Instaloader will store session files
 SESSION_DIR: str = os.getenv("SESSION_DIR", "sessions")
+
+# Optional SSL certificate and key for running the web server over HTTPS
+SSL_CERTFILE: str | None = os.getenv("SSL_CERTFILE")
+SSL_KEYFILE: str | None = os.getenv("SSL_KEYFILE")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,8 @@ def test_loads_env_variables(monkeypatch):
     monkeypatch.setenv("INSTAGRAM_USER", "user123")
     monkeypatch.setenv("INSTAGRAM_PASSWORD", "pass123")
     monkeypatch.setenv("SESSION_DIR", "my_sessions")
+    monkeypatch.setenv("SSL_CERTFILE", "/tmp/cert.pem")
+    monkeypatch.setenv("SSL_KEYFILE", "/tmp/key.pem")
 
     # Reload config after setting env vars and stubbing dotenv
     config = importlib.import_module("config")
@@ -22,3 +24,5 @@ def test_loads_env_variables(monkeypatch):
     assert config.INSTAGRAM_USER == "user123"
     assert config.INSTAGRAM_PASSWORD == "pass123"
     assert config.SESSION_DIR == "my_sessions"
+    assert config.SSL_CERTFILE == "/tmp/cert.pem"
+    assert config.SSL_KEYFILE == "/tmp/key.pem"

--- a/web_app.py
+++ b/web_app.py
@@ -1,14 +1,20 @@
 import asyncio
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+
+import uvicorn
 from instaloader import Profile
 
 # Reuse the Instaloader instance from bot.py
 from bot import L, INSTAGRAM_USER, INSTAGRAM_PASSWORD
+from config import SSL_CERTFILE, SSL_KEYFILE
 
 app = FastAPI(title="Telegram InstaBot Web API")
+app.add_middleware(HTTPSRedirectMiddleware)
 
 
 @app.on_event("startup")
@@ -69,3 +75,13 @@ async def download_stories():
         return FileResponse(archive_path, filename="stories_archive.zip")
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to download stories")
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "web_app:app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        ssl_keyfile=SSL_KEYFILE,
+        ssl_certfile=SSL_CERTFILE,
+    )


### PR DESCRIPTION
## Summary
- add optional SSL configuration values
- secure web server with `HTTPSRedirectMiddleware`
- run web_app via uvicorn with SSL settings
- document new `.env` variables and how to start HTTPS server
- test additional config options

## Testing
- `pytest -q`